### PR TITLE
Support full request/response tampering features in 'http_tamperer'

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -16,9 +16,9 @@ loglevel: 1
 ## Currently supports `tcp_proxy` and `http_proxy`.
 proxy:
 
-  ## Configures a TCP proxy
-  ##
-  ## NOTE: TLS is currently not supported
+  # Configures a TCP proxy
+  #
+  # NOTE: TLS is currently not supported
   - name: tcp_proxy
     config:
       host: 0.0.0.0           # Local address to bind to and accept connections. May be an IP/hostname
@@ -55,11 +55,37 @@ middleware:
   ##
   - name: http_tamperer
     config:
-      status: 401              # Override HTTP Status code
-      headers:                 # Override response headers
-        content_length: "27"
-        x_foo_bar:      "baz"
-      body:      "my new body" # Override response body
+      request:
+        method:           "GET"  # Override request method
+        headers:
+          x_my_request:   "foo"  # Override request header
+          content_type: "application/x-www-form-urlencoded"
+          content_length: "5"
+        cookies:                 # Custom request cookies
+            - name: "fooreq"
+              value: "blahaoeuaoeu"
+              domain: "localhost"
+              path: "/foopath"
+              secure: true
+              rawexpires: "Sat, 12 Sep 2015 09:19:48 UTC"
+              maxage: 200
+              httponly: true
+        body: "wow, new body!"   # Override request body
+      response:
+        status: 201              # Override HTTP Status code
+        headers:                 # Override response headers
+          content_length: "27"
+          x_foo_bar:      "baz"
+        body:      "my new body" # Override response body
+        cookies:                 # Custom response cookies
+            - name: "foo"
+              value: "blahaoeuaoeu"
+              domain: "localhost"
+              path: "/foopath"
+              secure: true
+              rawexpires: "Sat, 12 Sep 2015 09:19:48 UTC"
+              maxage: 200
+              httponly: true
 
   ## Request Logger - use this to see what's going in/out of the Proxy.
   ##

--- a/protocol/reverse_proxy.go
+++ b/protocol/reverse_proxy.go
@@ -192,7 +192,7 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	// Fire Pre-dispatch middleware event
-	ctx := &muxy.Context{Request: req}
+	ctx := &muxy.Context{Request: outreq}
 	for _, middleware := range p.Middleware {
 		middleware.HandleEvent(muxy.EVENT_PRE_DISPATCH, ctx)
 	}

--- a/symptom/http_tamperer.go
+++ b/symptom/http_tamperer.go
@@ -1,21 +1,34 @@
 package symptom
 
 import (
-	"fmt"
+	"bytes"
 	"github.com/mefellows/muxy/log"
 	"github.com/mefellows/muxy/muxy"
 	"github.com/mefellows/plugo/plugo"
 	"io"
 	"net/http"
+	//"net/http/httptest"
 	"strings"
+	"time"
 )
 
-// 50x, 40x etc.
+type RequestConfig struct {
+	Method  string
+	Headers map[string]string
+	Cookies []http.Cookie
+	Body    string
+}
+
+type ResponseConfig struct {
+	Headers map[string]string
+	Cookies []http.Cookie
+	Body    string
+	Status  int
+}
 
 type HttpTampererSymptom struct {
-	Status  int `required:"true" default:"500"`
-	Headers map[string]string
-	Body    string
+	Request  RequestConfig
+	Response ResponseConfig
 }
 
 func init() {
@@ -54,43 +67,98 @@ func (r *responseBody) Read(p []byte) (int, error) {
 
 func (m *HttpTampererSymptom) HandleEvent(e muxy.ProxyEvent, ctx *muxy.Context) {
 	switch e {
+	case muxy.EVENT_PRE_DISPATCH:
+		m.MuckRequest(ctx)
 	case muxy.EVENT_POST_DISPATCH:
-		log.Debug("Spoofing status code, responding with %s", log.Colorize(log.YELLOW, fmt.Sprintf("%d %s", m.Status, http.StatusText(m.Status))))
-
-		// Body
-		if m.Body != "" {
-			var cl io.ReadCloser
-			cl = &responseBody{body: []byte(m.Body)}
-			r := &http.Response{
-				Request:          ctx.Request,
-				Header:           ctx.Response.Header,
-				Close:            ctx.Response.Close,
-				ContentLength:    ctx.Response.ContentLength,
-				Trailer:          ctx.Response.Trailer,
-				TLS:              ctx.Response.TLS,
-				TransferEncoding: ctx.Response.TransferEncoding,
-				Status:           ctx.Response.Status,
-				StatusCode:       ctx.Response.StatusCode,
-				Proto:            ctx.Response.Proto,
-				ProtoMajor:       ctx.Response.ProtoMajor,
-				ProtoMinor:       ctx.Response.ProtoMinor,
-				Body:             cl,
-			}
-			log.Debug("Injecting HTTP Response Body with %s", log.Colorize(log.BLUE, m.Body))
-			*ctx.Response = *r
-		}
-
-		// Set Headers
-		for k, v := range m.Headers {
-			key := strings.ToTitle(strings.Replace(k, "_", "-", -1))
-			log.Debug("Spoofing Header %s => %s", log.Colorize(log.LIGHTMAGENTA, key), v)
-			ctx.Response.Header.Add(key, v)
-			ctx.ResponseWriter.Header().Add(key, v)
-		}
-
-		// This Writes all headers, setting status code - so call this last
-		ctx.Response.StatusCode = m.Status
-		ctx.Response.Status = http.StatusText(m.Status)
-		ctx.ResponseWriter.WriteHeader(m.Status)
+		m.MuckResponse(ctx)
 	}
+}
+
+func (m *HttpTampererSymptom) MuckRequest(ctx *muxy.Context) {
+
+	// Body
+	if m.Request.Body != "" {
+		newreq, err := http.NewRequest(ctx.Request.Method, ctx.Request.URL.String(), bytes.NewBuffer([]byte(m.Request.Body)))
+		if err != nil {
+			log.Error(err.Error())
+		}
+		*ctx.Request = *newreq
+		log.Debug("Spoofing HTTP Request Body with %s", log.Colorize(log.BLUE, m.Request.Body))
+	}
+
+	// Set Cookies
+	for _, c := range m.Request.Cookies {
+		c.Expires = stringToDate(c.RawExpires)
+		log.Debug("Spoofing Request Cookie %s => %s", log.Colorize(log.LIGHTMAGENTA, c.Name), c.String())
+		ctx.Request.Header.Add("Cookie", c.String())
+	}
+
+	// Set Headers
+	for k, v := range m.Request.Headers {
+		key := strings.ToTitle(strings.Replace(k, "_", "-", -1))
+		log.Debug("Spoofing Request Header %s => %s", log.Colorize(log.LIGHTMAGENTA, key), v)
+		ctx.Request.Header.Set(key, v)
+	}
+
+	// This Writes all headers, setting status code - so call this last
+	if m.Request.Method != "" {
+		ctx.Request.Method = m.Request.Method
+	}
+}
+func (m *HttpTampererSymptom) MuckResponse(ctx *muxy.Context) {
+
+	// Body
+	if m.Response.Body != "" {
+		var cl io.ReadCloser
+		cl = &responseBody{body: []byte(m.Response.Body)}
+		r := &http.Response{
+			Request:          ctx.Request,
+			Header:           ctx.Response.Header,
+			Close:            ctx.Response.Close,
+			ContentLength:    ctx.Response.ContentLength,
+			Trailer:          ctx.Response.Trailer,
+			TLS:              ctx.Response.TLS,
+			TransferEncoding: ctx.Response.TransferEncoding,
+			Status:           ctx.Response.Status,
+			StatusCode:       ctx.Response.StatusCode,
+			Proto:            ctx.Response.Proto,
+			ProtoMajor:       ctx.Response.ProtoMajor,
+			ProtoMinor:       ctx.Response.ProtoMinor,
+			Body:             cl,
+		}
+		log.Debug("Injecting HTTP Response Body with %s", log.Colorize(log.BLUE, m.Response.Body))
+		*ctx.Response = *r
+	}
+
+	// Set Cookies
+	for _, c := range m.Response.Cookies {
+		c.Expires = stringToDate(c.RawExpires)
+		log.Debug("Spoofing Response Cookie %s => %s", log.Colorize(log.LIGHTMAGENTA, c.Name), c.String())
+		ctx.Response.Header.Add("Set-Cookie", c.String())
+	}
+
+	// Set Headers
+	for k, v := range m.Response.Headers {
+		key := strings.ToTitle(strings.Replace(k, "_", "-", -1))
+		log.Debug("Spoofing Response Header %s => %s", log.Colorize(log.LIGHTMAGENTA, key), v)
+		ctx.Response.Header.Add(key, v)
+	}
+
+	// This Writes all headers, setting status code - so call this last
+	if m.Response.Status != 0 {
+		ctx.Response.StatusCode = m.Response.Status
+		ctx.Response.Status = http.StatusText(m.Response.Status)
+	}
+}
+
+func stringToDate(val string) time.Time {
+
+	exptime, err := time.Parse(time.RFC1123, val)
+	if err != nil {
+		exptime, err = time.Parse("Mon, 02-Jan-2006 15:04:05 MST", val)
+		if err != nil {
+			return time.Time{}
+		}
+	}
+	return exptime.UTC()
 }

--- a/symptom/http_tamperer_test.go
+++ b/symptom/http_tamperer_test.go
@@ -1,1 +1,26 @@
 package symptom
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestCreateCookieHeader(t *testing.T) {
+	cookies := []http.Cookie{
+		http.Cookie{
+			Domain:   "foo.com",
+			Expires:  time.Now(),
+			HttpOnly: true,
+			MaxAge:   1,
+			Name:     "Foo",
+			Path:     "/",
+			Secure:   false,
+			Value:    "blah",
+		},
+	}
+	for _, c := range cookies {
+		t.Logf("cookie: %s", c.String())
+
+	}
+}


### PR DESCRIPTION
Support full tampering feature set for the 'http_tamperer' middleware:

*Request*:
* Headers
* Cookies
* Method
* Body

*Response*
* Headers
* Cookies
* Body
* Status Code