### PR TITLE
HTTPS proxy implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,11 @@ proxy:
   - name: http_proxy
     config:
       host: 0.0.0.0
+      protocol: http
       port: 8181
       proxy_host: 0.0.0.0
       proxy_port: 8282
+      proxy_protocol: https
 ```
 
 #### TCP Proxy

--- a/command/commands.go
+++ b/command/commands.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	pki "github.com/mefellows/pkigo/command"
 	"github.com/mitchellh/cli"
 	"os"
 )
@@ -26,6 +27,9 @@ func init() {
 			return &ProxyCommand{
 				Meta: meta,
 			}, nil
+		},
+		"pki": func() (cli.Command, error) {
+			return &pki.PkiCommand{}, nil
 		},
 	}
 }

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -23,10 +23,10 @@ proxy:
     config:
       host: 0.0.0.0           # Local address to bind to and accept connections. May be an IP/hostname
       port: 8080              # Local port to bind to
-      proxy_host: 0.0.0.0
-      proxy_port: 2000
-      nagles_algorithm: true
-      packet_size: 64
+      proxy_host: 0.0.0.0     # Proxy server port
+      proxy_port: 2000        # Proxied server port
+      nagles_algorithm: true  # Use Nagles algorithm?
+      packet_size: 64         # Size of each contiguous network packet to proxy
 
   ## HTTP Proxy: Configures an HTTP Proxy
   ##
@@ -35,8 +35,10 @@ proxy:
     config:
       host: 0.0.0.0
       port: 8181
+      protocol: http
       proxy_host: 0.0.0.0
       proxy_port: 8282
+      proxy_protocol: http
 
 ## Middleware
 ##


### PR DESCRIPTION
Extension to the `http_proxy` Proxy, it now supports `protocol` and `proxy_protocol` to specify the protocol to listen on and to proxy respectively.